### PR TITLE
Only copying the _stakes.length to memory instead of the whole array

### DIFF
--- a/contracts/StakeManager.sol
+++ b/contracts/StakeManager.sol
@@ -123,16 +123,16 @@ contract StakeManager is IStakeManager, Shared, ReentrancyGuard, IERC777Recipien
     function getUpdatedExecRes() public view override returns (uint96 epoch, uint randNum, uint idxOfExecutor, address exec) {
         epoch = getCurEpoch();
         // So that the storage is only loaded once
-        address[] memory stakes = _stakes;
+        uint stakesLen = _stakes.length;
         // If the executor is out of date and the system already has stake,
         // choose a new executor. This will do nothing if the system is starting
         // and allow someone to stake without needing there to already be existing stakes
-        if (_executor.forEpoch != epoch && stakes.length > 0) {
+        if (_executor.forEpoch != epoch && stakesLen > 0) {
             // -1 because blockhash(seed) in Oracle will return 0x00 if the
             // seed == this block's height
             randNum = _oracle.getRandNum(epoch - 1);
-            idxOfExecutor = randNum % stakes.length;
-            exec = stakes[idxOfExecutor];
+            idxOfExecutor = randNum % stakesLen;
+            exec = _stakes[idxOfExecutor];
         }
     }
 

--- a/tests/stateful/test_stakeManager.py
+++ b/tests/stateful/test_stakeManager.py
@@ -4,7 +4,7 @@ from brownie import reverts, chain, web3
 from brownie.test import strategy
 
 
-settings = {"stateful_step_count": 200, "max_examples": 500}
+settings = {"stateful_step_count": 100, "max_examples": 200}
 
 def test_stakeManager(BaseStateMachine, state_machine, a, cleanAUTO, evmMaths):
 


### PR DESCRIPTION
Fix an issue where all of `_stakes` was loaded into memory, which does not save gas and can potentially brick the contract (though that would be pretty hard to do)